### PR TITLE
chore(deps): update docker image registry1.dso.mil/ironbank/external-…

### DIFF
--- a/external-dns/zarf.yaml
+++ b/external-dns/zarf.yaml
@@ -34,4 +34,4 @@ components:
         - ../values/aws-external-dns.yaml
     images:
       # renovate: datasource=docker
-      - registry1.dso.mil/ironbank/external-dns:v0.11.0
+      - registry1.dso.mil/ironbank/external-dns:v0.13.4


### PR DESCRIPTION
…dns to v0.13.4 (#78)

deps: update helm chart external-dns to v1.13.0 (#75)

deps: update docker image registry1.dso.mil/ironbank/external-dns to v0.13.4 (#78)

| datasource | package                                 | from    | to      |
| ---------- | --------------------------------------- | ------- | ------- |
| docker     | registry1.dso.mil/ironbank/external-dns | v0.11.0 | v0.13.4 |